### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/CMaassen2/4594ebeb-18e8-4b31-9c04-0936d622c658/e9dd7c7e-d3f6-42d7-8b12-7535b6189ee3/_apis/work/boardbadge/250b3105-c744-409d-919e-007c0a358a7c)](https://dev.azure.com/CMaassen2/4594ebeb-18e8-4b31-9c04-0936d622c658/_boards/board/t/e9dd7c7e-d3f6-42d7-8b12-7535b6189ee3/Microsoft.RequirementCategory)
 # azure-functions


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/CMaassen2/4594ebeb-18e8-4b31-9c04-0936d622c658/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.